### PR TITLE
Fix app name from React App to MLA2Z

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "MLA2Z",
+  "name": "MLA2Z",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
Changed the "short name" and "name" property in the manifest.json file to MLA2Z (was originally React App and Create React App). 